### PR TITLE
Add TimeInterval object

### DIFF
--- a/lib/timerage.rb
+++ b/lib/timerage.rb
@@ -1,29 +1,19 @@
 require "timerage/version"
 
 module Timerage
+  autoload :TimeInterval, "timerage/time_interval"
+
   refine Range do
     def step(n, &blk)
       if self.begin.kind_of?(Time) || self.begin.kind_of?(Date)
-        if block_given?
-          time_enumerator(n).each(&blk)
-        else
-          time_enumerator(n)
-        end
+        Timerage::TimeInterval.new(self).step(n, &blk)
       else
         super
       end
     end
 
-    def time_enumerator(step)
-      Enumerator.new do |y|
-        nxt = self.begin
-
-        while nxt <= self.end do
-          y << nxt
-
-          nxt += step
-        end
-      end
+    def to_time_interval
+      Timerage::TimeInterval.new(self)
     end
   end
 end

--- a/lib/timerage/time_interval.rb
+++ b/lib/timerage/time_interval.rb
@@ -1,0 +1,51 @@
+require "delegate"
+
+module Timerage
+  # A range of time. The exposes the Range like interface.
+  class TimeInterval < DelegateClass(Range)
+    def initialize(*args)
+      rng = if rangeish?(args.first)
+              args.first
+            else
+              Range.new(*args)
+            end
+
+      super rng
+    end
+
+    alias_method :to_time, :begin
+
+    def step(n, &blk)
+      if block_given?
+        time_enumerator(n).each(&blk)
+      else
+        time_enumerator(n)
+      end
+    end
+
+    protected
+
+    def rangeish?(an_obj)
+      an_obj.respond_to?(:begin) &&
+        an_obj.respond_to?(:end)
+    end
+
+    def time_enumerator(step)
+      not_done = if exclude_end?
+                   ->(nxt) { nxt < self.end }
+                 else
+                   ->(nxt) { nxt <= self.end }
+                 end
+
+      Enumerator.new do |y|
+        nxt = self.begin
+
+        while not_done.call(nxt) do
+          y << nxt
+
+          nxt += step
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+require 'rspec'
+
+require 'timerage'

--- a/spec/timerage/time_interval_spec.rb
+++ b/spec/timerage/time_interval_spec.rb
@@ -1,0 +1,58 @@
+require_relative "../spec_helper"
+
+describe Timerage::TimeInterval do
+  describe "creation" do
+    specify { expect(described_class.new(now-1..now)).to be_kind_of described_class }
+    specify { expect(described_class.new(now-1, now)).to be_kind_of described_class }
+    specify { expect(described_class.new(now-1, now, true)).to be_kind_of described_class }
+    specify { expect(described_class.new(now-1, now, false )).to be_kind_of described_class }
+  end
+
+  subject(:interval) { described_class.new(now-duration, now) }
+
+  it { is_expected.to behave_like_a Range }
+  specify { expect(interval.begin).to eq now - duration }
+  specify { expect(interval.end).to eq now }
+  specify { expect(interval.to_time).to behave_like_a Time }
+  specify { expect(interval.to_time).to (be >= interval.begin)
+      .and (be <= interval.end) }
+  specify { expect{|b| interval.step(1200, &b) }
+      .to yield_control.at_least(:once) }
+
+  context "interval include end" do
+    specify { expect(interval.exclude_end?).to be false }
+    specify { expect(interval.cover? now).to be true }
+    specify { expect(interval.cover? now - duration).to be true }
+    specify { expect(interval.cover? now - (duration/2)).to be true }
+    specify { expect(interval.cover? now + 1).to be false }
+    specify { expect(interval.cover? now - (duration + 1)).to be false }
+
+    specify { expect{|b| interval.step(1200, &b) }
+        .to yield_successive_args now-duration, now-(duration-1200), now-(duration-2400), now }
+
+  end
+
+  context "interval exclude end" do
+    subject(:interval) { described_class.new(now-duration...now) }
+
+    specify { expect(interval.exclude_end?).to be true }
+    specify { expect(interval.cover? now).to be false }
+    specify { expect(interval.cover? now - duration).to be true }
+    specify { expect(interval.cover? now - (duration/2)).to be true }
+    specify { expect(interval.cover? now + 1).to be false }
+    specify { expect(interval.cover? now - (duration + 1)).to be false }
+
+    specify { expect{|b| interval.step(1200, &b) }
+        .to yield_successive_args now-duration, now-(duration-1200), now-(duration-2400) }
+
+  end
+
+  let(:now) { Time.now }
+  let(:duration) { 3600 }
+
+  matcher :behave_like_a do |expected|
+    match do |actual|
+      Set[*expected.instance_methods].subset? Set[*actual.methods]
+    end
+  end
+end

--- a/spec/timerage_spec.rb
+++ b/spec/timerage_spec.rb
@@ -1,0 +1,28 @@
+require_relative "spec_helper"
+
+describe Timerage do
+  begin
+    using Timerage
+
+    subject(:range) { Range.new(now-duration, now) }
+
+    specify { expect(range.to_time_interval).to be_kind_of Timerage::TimeInterval }
+    specify { expect{|b| range.step(1200, &b) }.to yield_control.at_least(:once) }
+
+    context "interval include end" do
+      specify { expect{|b| range.step(1200, &b) }
+          .to yield_successive_args now-duration, now-(duration-1200), now-(duration-2400), now }
+
+  end
+
+    context "interval exclude end" do
+      subject (:range) { Range.new(now-duration, now, true) }
+
+      specify { expect{|b| range.step(1200, &b) }
+          .to yield_successive_args now-duration, now-(duration-1200), now-(duration-2400) }
+    end
+
+    let(:now) { Time.now }
+    let(:duration) { 3600 }
+  end
+end

--- a/timerage.gemspec
+++ b/timerage.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec", ["> 3.0.0.a", "< 4"]
 end


### PR DESCRIPTION
Allows us to more easily provide time interval specific functionality and not have to put `using Timerage` all over the place.
