### PR TITLE
iterate over a range correctly when step is variable length duration

### DIFF
--- a/lib/timerage/time_interval.rb
+++ b/lib/timerage/time_interval.rb
@@ -6,7 +6,7 @@ module Timerage
 
     class << self
       def new(*args)
-        args = [args.first.begin, args.first.end, args.first.exclude_end?] if args.first.respond_to?(:exclude_end?) 
+        args = [args.first.begin, args.first.end, args.first.exclude_end?] if args.first.respond_to?(:exclude_end?)
         new_obj = allocate
         new_obj.send(:initialize, *args)
         new_obj
@@ -135,13 +135,12 @@ module Timerage
     end
 
     def time_enumerator(step)
-      count = (self.end - self.begin).div(step) + 1
-      count -= 1 if exclude_end? and (self.end - self.begin) % step == 0
-      # We've included our end if it should be
+      next_offset = 0.seconds
 
       Enumerator.new do |y|
-        (count).times do |offset|
-          y << self.begin + (step * offset)
+        while self.cover?(self.begin + next_offset)
+          y << self.begin + next_offset
+          next_offset += step
         end
       end
     end

--- a/lib/timerage/version.rb
+++ b/lib/timerage/version.rb
@@ -1,3 +1,3 @@
 module Timerage
-  VERSION = "2.1.0"
+  VERSION = "2.1.1"
 end

--- a/spec/timerage/time_interval_spec.rb
+++ b/spec/timerage/time_interval_spec.rb
@@ -47,7 +47,13 @@ describe Timerage::TimeInterval do
   specify { expect(interval.to_time).to (be >= interval.begin)
       .and (be <= interval.end) }
   specify { expect{|b| interval.step(1200, &b) }
-      .to yield_control.at_least(:once) }
+              .to yield_control.at_least(:once) }
+
+  specify { expect{|b|
+              Timerage(Time.parse("2019-08-01 01:00:00 UTC")...Time.parse("2019-09-01 01:00:00 UTC"))
+                .step(1.month, &b)
+            }.to yield_control.exactly(:once) }
+
   specify { expect(interval.iso8601)
             .to eq "#{interval.begin.iso8601}/#{interval.end.iso8601}" }
   specify { expect(interval.iso8601(3))

--- a/timerage.gemspec
+++ b/timerage.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", ["> 3.0.0.a", "< 4"]
   spec.add_development_dependency "activesupport"


### PR DESCRIPTION
for example, `.step(1.month)`