### PR TITLE
Return date objects when stepping over a date range with a day size

### DIFF
--- a/lib/timerage/time_interval.rb
+++ b/lib/timerage/time_interval.rb
@@ -135,7 +135,7 @@ module Timerage
     end
 
     def time_enumerator(step)
-      next_offset = 0.seconds
+      next_offset = (self.begin + step).is_a?(Date) ? 0.days : 0.seconds
 
       Enumerator.new do |y|
         while self.cover?(self.begin + next_offset)

--- a/lib/timerage/time_interval.rb
+++ b/lib/timerage/time_interval.rb
@@ -135,7 +135,7 @@ module Timerage
     end
 
     def time_enumerator(step)
-      next_offset = (self.begin + step).is_a?(Date) ? 0.days : 0.seconds
+      next_offset = step * 0
 
       Enumerator.new do |y|
         while self.cover?(self.begin + next_offset)

--- a/spec/timerage/time_interval_spec.rb
+++ b/spec/timerage/time_interval_spec.rb
@@ -214,6 +214,22 @@ describe Timerage::TimeInterval do
     specify { expect{ |b| subject.step(3_600, &b) }.to yield_control.exactly(2).times }
   end
 
+  context "When given date range" do
+    it "returns date objects when stepping through the range with a day duration" do
+      date_range = Date.new(2020, 1, 1)..Date.new(2020,1,3)
+      described_class.new(date_range).step(1.day) do |date|
+        expect(date).to be_kind_of Date
+      end
+    end
+
+    it "returns Time objects when stepping through the range with an hour duration" do
+      date_range = Date.new(2020, 1, 1)..Date.new(2020,1,2)
+      described_class.new(date_range).step(6.hours) do |date|
+        expect(date).to be_kind_of Time
+      end
+    end
+  end
+
   let(:leap_day) { Time.parse("2016-02-29 12:00:00 UTC") }
   let(:before_leap_day) { leap_day - 1.day }
   let(:after_leap_day) { leap_day + 1.day}


### PR DESCRIPTION
### Issue
When given a date range and you step through the range with a day duration (like 3.days), the first item that gets returned is a `Time` object and the rest `Date` objects.

### Reasoning why this happens
In `time_enumerator` the initial next_offset is 0.seconds which causes a type conversion when being added to a date object. This only affects the first item.

### What has been changed?
- The initial next_offset value is set based on if next item is a Date or Time object. 