### PR TITLE
Refactor slice to use steps from time_enumerator

### DIFF
--- a/lib/timerage/time_interval.rb
+++ b/lib/timerage/time_interval.rb
@@ -32,12 +32,12 @@ module Timerage
       end
     end
 
-    def slice(seconds)
-      time_enumerator(seconds)
-        .map{|t|
-          end_time = [t+seconds, self.end].min
-          inclusive = (t == end_time || t+seconds > self.end) && !exclude_end?
-          TimeInterval.new(t, end_time, !inclusive) }
+    def slice(duration)
+      time_enumerator(duration)
+        .each_cons(2).map { |s_begin, s_end| TimeInterval.new(s_begin, s_end, exclusive_end_slice?(s_end)) }
+        .then do |slices|
+          slices << TimeInterval.new(slices.last.end, self.end, exclusive_end_slice?(slices.last.end + duration)) if slices.present?
+        end
     end
 
     # Return new TimeInterval that is the concatenation of self and
@@ -132,6 +132,10 @@ module Timerage
     def rangeish?(an_obj)
       an_obj.respond_to?(:begin) &&
         an_obj.respond_to?(:end)
+    end
+
+    def exclusive_end_slice?(slice_end)
+      !((slice_end > self.end) && !exclude_end?)
     end
 
     def time_enumerator(step)

--- a/spec/timerage/time_interval_spec.rb
+++ b/spec/timerage/time_interval_spec.rb
@@ -230,6 +230,14 @@ describe Timerage::TimeInterval do
     end
   end
 
+  context "produces complete slices" do
+    it "slices a range into intervals without missing any time inbetween" do
+      range = Timerage(Time.parse("2023-10-31T00:00:00+00:00")...Time.parse("2024-06-30 00:00:00 UTC"))
+      slices = range.slice(1.month)
+      expect(slices.map(&:duration).sum).to eq range.duration
+    end
+  end
+
   let(:leap_day) { Time.parse("2016-02-29 12:00:00 UTC") }
   let(:before_leap_day) { leap_day - 1.day }
   let(:after_leap_day) { leap_day + 1.day}


### PR DESCRIPTION
### Why?
- Slice on month duration provides incorrect slices
```
test_range = Timerage(Time.parse("2023-10-31T00:00:00+00:00")...Time.parse("2024-06-30 00:00:00 UTC"))
period = 1.month
test_range.slice(period)

# Produces output
[2023-10-31 00:00:00 +0000...2023-11-30 00:00:00 +0000,
 2023-11-30 00:00:00 +0000...2023-12-30 00:00:00 +0000, This slice is missing a day, slice should have ended on the 31st
 2023-12-31 00:00:00 +0000...2024-01-31 00:00:00 +0000, Starts on the 31st
 2024-01-31 00:00:00 +0000...2024-02-29 00:00:00 +0000,
 2024-02-29 00:00:00 +0000...2024-03-29 00:00:00 +0000, Similar issue here
 2024-03-31 00:00:00 +0000...2024-04-30 00:00:00 +0000, Missing 2 days
 2024-04-30 00:00:00 +0000...2024-05-30 00:00:00 +0000,
 2024-05-31 00:00:00 +0000...2024-06-30 00:00:00 +0000]
```

### What has changed?
- Refactor slice to use `each_cons`. This helps use the steps provided by time_enumerator to avoid slices missing days
- Add special case to handle creating last slice